### PR TITLE
feature: destroy markers if current key matches with no current marker characters

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -59,15 +59,12 @@ export default class Vimium extends Plugin {
 					this.showMarkers = false;
 					this.destroyMarkers();
 					this.input = "";
+				} else if (isMarkerMatchAt(this.input, this.markers, this.input.length - 1)) {
+					this.updateMarkers();
 				} else {
-					if (isMarkerMatchAt(this.input, this.markers, this.input.length - 1)) {
-						this.updateMarkers();
-					}
-					else {
-						this.showMarkers = false;
-						this.destroyMarkers();
-						this.input = "";
-					}
+					this.showMarkers = false;
+					this.destroyMarkers();
+					this.input = "";
 				}
 			}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { Plugin } from 'obsidian';
 import { DEFAULT_SETTINGS, VimiumSettings, VimiumSettingTab } from './settings';
 import tlds from './tlds';
 import { MarkerData } from './types';
-import { createMarker, findMarkerMatch, updateMarkerText } from './utils';
+import { createMarker, findMarkerMatch, isMarkerMatchAt, updateMarkerText } from './utils';
 
 export default class Vimium extends Plugin {
 	settings: VimiumSettings;
@@ -60,7 +60,14 @@ export default class Vimium extends Plugin {
 					this.destroyMarkers();
 					this.input = "";
 				} else {
-					this.updateMarkers();
+					if (isMarkerMatchAt(this.input, this.markers, this.input.length - 1)) {
+						this.updateMarkers();
+					}
+					else {
+						this.showMarkers = false;
+						this.destroyMarkers();
+						this.input = "";
+					}
 				}
 			}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,6 +55,16 @@ export function findMarkerMatch(text: string, markers: MarkerData[]): MarkerData
 	return null;
 }
 
+export function isMarkerMatchAt(key: string, markers: MarkerData[], index: number): boolean {
+	for (const marker of markers) {
+		if (key === marker.text[index]) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 export function intToLetters(num: number) {
 	return String.fromCharCode(97 + (num % 26));
 }


### PR DESCRIPTION
[Chrome Vimium](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/philc/vimium&ved=2ahUKEwiD8uTciqeJAxVMh68BHQ0nEAQQFnoECBIQAQ&usg=AOvVaw0IN0ftvgZXlY3C5CamkiB5) destroys all markers if the current key matches with no current marker characters
Given following circumstances, for example,
```
markers = ['ab', 'ac', 'ad']
input = 'a'
```
if the current `event.key` is 'e' which does not match with any of the current marker characters ('b', 'c', 'd'),
the marker should disappear and also be disabled.

Unfortunately, existing code in obsidian vimium does make the markers disappear but not disable them. 
This leads to an issue where no keyboard input works at all, that is, disabling any [a-zA-Z] keyboard inputs due to `event.preventDefault();`.

This PR aims to mitigate this issue and align with [Chrome Vimium](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://github.com/philc/vimium&ved=2ahUKEwiD8uTciqeJAxVMh68BHQ0nEAQQFnoECBIQAQ&usg=AOvVaw0IN0ftvgZXlY3C5CamkiB5).
This PR checks if the current `event.key` matches with any of currenct marker characters and if so, marker is not only destroyed but also disabled.
