### PR TITLE
 Improved plugin performance by more than 20x.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
 import { Plugin } from 'obsidian';
 import { DEFAULT_SETTINGS, VimiumSettings, VimiumSettingTab } from './settings';
-import tlds from './tlds';
 import { MarkerData } from './types';
-import { createMarker, findMarkerMatch, updateMarkerText } from './utils';
+import { createMarker, findMarkerMatch, updateMarkerText, generateHints } from './utils';
 
 export default class Vimium extends Plugin {
 	settings: VimiumSettings;
@@ -99,10 +98,11 @@ export default class Vimium extends Plugin {
 		});
 
 		// Create markers
-		for (let i = 0; i < Math.min(clickableElements.length, tlds.length); i++) {
-			const clickableEl = clickableElements[i] as HTMLElement;
-			const text = tlds[i];
-			const marker = createMarker(text, clickableEl, this.input);
+		const hintChars = this.settings.hintChars;
+		const hints = generateHints(clickableElements.length, hintChars);
+		for (const [index, hint] of hints.entries()) {
+			const clickableEl = clickableElements[index] as HTMLElement;
+			const marker = createMarker(hint, clickableEl, this.input);
 			if (marker) {
 				this.markers.push(marker);
 				containerInnerEl.appendChild(marker.el);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,11 +5,13 @@ import Vimium from "./main";
 export interface VimiumSettings {
 	clickableCssSelector: string;
 	markerSize: number;
+	hintChars: string;
 }
 
 export const DEFAULT_SETTINGS: VimiumSettings = {
 	clickableCssSelector: CLICKABLE_SELECTOR,
 	markerSize: 12,
+	hintChars: "sadjklewcmpgh",
 }
 
 export class VimiumSettingTab extends PluginSettingTab {
@@ -23,6 +25,21 @@ export class VimiumSettingTab extends PluginSettingTab {
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName("Link hints characters")
+			.setDesc("Characters used for generating link hints. More characters generates shorter hints. Minimum 3 characters.")
+			.addText((text) =>
+				text
+					.setPlaceholder("Characters...")
+					.setValue(this.plugin.settings.hintChars)
+					.onChange(async (value) => {
+						if (!value || value.length < 3) 
+                            value = DEFAULT_SETTINGS.hintChars;
+						this.plugin.settings.hintChars = value;
+						await this.plugin.saveSettings();
+					})
+			);
 
 		new Setting(containerEl)
 			.setName('Marker font size')

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type MarkerData = {
 	el: HTMLElement;
 	parentEl: HTMLElement;
-	text: string;
+	hint: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { MarkerData } from "./types";
 
-export function createMarkerText(text: string, markerEl: HTMLElement, input = "") {
-	Array.from(text).forEach((char, index) => {
+export function createMarkerText(hint: string, markerEl: HTMLElement, input = "") {
+	Array.from(hint).forEach((char, index) => {
 		const charEl = createSpan();
 		charEl.setText(char.toUpperCase());
 		if (input.length >= index && char === input[index]) {
@@ -12,47 +12,26 @@ export function createMarkerText(text: string, markerEl: HTMLElement, input = ""
 }
 
 export function updateMarkerText(marker: MarkerData, input = "") {
-	while (marker.el.firstChild) {
-		marker.el.removeChild(marker.el.firstChild);
-	}
-	createMarkerText(marker.text, marker.el, input);
+    marker.el.innerHTML = "";
+	createMarkerText(marker.hint, marker.el, input);
 }
 
-export function createMarkerEl(text: string, input: string, x: number, y: number): HTMLElement {
+export function createMarkerEl(hint: string, input: string, x: number, y: number): HTMLElement {
 	const markerEl = createSpan()
 	markerEl.addClass("vimium-marker");
 	markerEl.setCssProps({
 		"--top": `${y}px`, 
 		"--left": `${x}px`,
 	});
-	createMarkerText(text, markerEl, input);
+	createMarkerText(hint, markerEl, input);
 	return markerEl;
 }
 
-export function createMarker(text: string, parentEl: HTMLElement, input = ""): MarkerData | null {
-	const rect = parentEl.getBoundingClientRect();
+export function createMarker(posX: number, posY: number, hint: string, 
+    parentEl: HTMLElement, input = ""): MarkerData {
 
-	if (rect.width === 0 || rect.height === 0) {
-		return null;
-	}
-
-	const data: MarkerData = {
-		el: createMarkerEl(text, input, rect.left, rect.top),
-		parentEl,
-		text
-	};
-
-	return data;
-}
-
-export function findMarkerMatch(text: string, markers: MarkerData[]): MarkerData | null {
-	for (const marker of markers) {
-		if (text === marker.text) {
-			return marker;
-		}
-	}
-
-	return null;
+    const el = createMarkerEl(hint, input, posX, posY);
+	return { el, parentEl, hint: hint };
 }
 
 export function intToLetters(num: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,3 +58,30 @@ export function findMarkerMatch(text: string, markers: MarkerData[]): MarkerData
 export function intToLetters(num: number) {
 	return String.fromCharCode(97 + (num % 26));
 }
+
+/**
+ * Generate hints using the `hintChars` character set. Hints can be of different
+ * lengths and are sorted in a way that hints starting with the same character
+ * are spread evenly.
+ * @param numHints The number of hints to generate.
+ * @param hintChars The characters to use for generating hints.
+ * @returns An array of hints.
+ */
+export function generateHints(numHints: number, hintChars: string): string[] {
+	if (!hintChars || hintChars.length == 0) return [];
+	let hints = [""];
+	let offset = 0;
+	while (hints.length - offset < numHints || hints.length === 1) {
+		const hint = hints[offset++];
+		for (const ch of hintChars) {
+			hints.push(ch + hint);
+		}
+	}
+	// Slice the hints to the number of hints requested, discarding those that
+	// share prefixes with other hints.
+	hints = hints.slice(offset, offset + numHints);
+
+	// Sort the hints and then reverse them, so that hints starting with the
+	// same character prefix are spread evenly throughout the array.
+	return hints.sort().map((hint) => hint.split("").reverse().join(""));
+}


### PR DESCRIPTION
**NOTE**: This PR includes the previous PR https://github.com/karstenpedersen/obsidian-vimium/pull/10 (Improved the way hints are generated).

main.ts:

- markers are now stored in a Map for O(1) access. There is no need for
    the findMarkerMatch function.
- The rectangle box information of each clickableElement is fetched in
    first place and stored, so there's no need to query again the DOM when
    creating the markers. This allows to avoid Layout Reflow penalties.
- clickableElements are now filtered, ditching elements out of workspace
    bounds, saving a lot of work that will be done for non displayed
    elements in the workspace.
- Remove the need to fetch markers rectangle box when updating markers.
    It only needs to hide discarded markers on user input and update hints
    on the remaining ones.

utils.ts:

- In updateMarkerText function remove childs more efficiently by setting
    innerHTML to "".
- In createMarker function posX and posY are passed as parameters, no
    need to fetch info from the DOM. No need to check if width and height
    are 0. If there was an element with this settings it was filtered out.

utils.ts, types.ts and main.ts:
   
 - Change text for hint to use the same term in all files.